### PR TITLE
Document explorer toolbar font icons not implemented

### DIFF
--- a/com.logilite.dms/src/com/logilite/dms/toolbar/CustomToolbarFactory.java
+++ b/com.logilite.dms/src/com/logilite/dms/toolbar/CustomToolbarFactory.java
@@ -111,4 +111,9 @@ public class CustomToolbarFactory implements IAction
 	{
 
 	}
+
+	@Override
+	public String getIconSclass() {
+		return "z-icon-DocumentExplorer";
+	}
 }


### PR DESCRIPTION
Issue: Document explorer toolbar font icons not implemented #1

Since the iDempiere ADTabPanel cannot find the icon css class in dms.css file, the current solution requires to have z-icon-DocumentExplorer icon in the iDempiere base theme ([font-icons.css.dsp](https://github.com/idempiere/idempiere/blob/master/org.adempiere.ui.zk/WEB-INF/src/web/theme/default/css/fragment/font-icons.css.dsp)):

```
.z-icon-DocumentExplorer:before {
	content: "\f07c";
}
```

It is missing currently, so the solution would be either to add it to iDempiere theme, or alternatively use the existing z-icon-Folder instead.
